### PR TITLE
Include email in the userData profile

### DIFF
--- a/src/Login.jsx
+++ b/src/Login.jsx
@@ -20,7 +20,7 @@ export default class Login extends Component {
 
   static defaultProps = {
     scope: '',
-    fields: ['id', 'first_name', 'last_name', 'middle_name',
+    fields: ['id', 'email', 'first_name', 'last_name', 'middle_name',
       'name', 'locale', 'gender', 'timezone', 'verified', 'link'],
     returnScopes: false,
     rerequest: false,


### PR DESCRIPTION
No idea why it is not included in the response by default.

`scope='email'` has no effect.

