### PR TITLE
Add support for auth_type reauthenticate

### DIFF
--- a/src/Login.jsx
+++ b/src/Login.jsx
@@ -24,21 +24,23 @@ export default class Login extends Process {
   async process(facebook) {
     const { scope, fields, returnScopes, rerequest, reauthorize } = this.props;
     const loginQpts = { scope };
-    let auth_type = [];
+    const authType = [];
 
     if (returnScopes) {
       loginQpts.return_scopes = true;
     }
 
     if (rerequest) {
-      auth_type.append('rerequest');
+      authType.append('rerequest');
     }
 
     if (reauthorize) {
-      auth_type.append('reauthenticate');
+      authType.append('reauthenticate');
     }
-
-    loginQpts.auth_type = auth_type.join(',');
+    
+    if (authType.length) {
+      loginQpts.auth_type = authType.join(',');
+    }
 
     const response = await facebook.login(loginQpts);
     if (response.status !== 'connected') {

--- a/src/Login.jsx
+++ b/src/Login.jsx
@@ -31,11 +31,11 @@ export default class Login extends Process {
     }
 
     if (rerequest) {
-      authType.append('rerequest');
+      authType.push('rerequest');
     }
 
     if (reauthorize) {
-      authType.append('reauthenticate');
+      authType.push('reauthenticate');
     }
     
     if (authType.length) {

--- a/src/Login.jsx
+++ b/src/Login.jsx
@@ -8,6 +8,7 @@ export default class Login extends Process {
     fields: PropTypes.array.isRequired,
     returnScopes: PropTypes.bool,
     rerequest: PropTypes.bool,
+    reauthorize: PropTypes.bool,
   };
 
   static defaultProps = {
@@ -17,19 +18,27 @@ export default class Login extends Process {
       'name', 'email', 'locale', 'gender', 'timezone', 'verified', 'link'],
     returnScopes: false,
     rerequest: false,
+    reauthorize: false,
   };
 
   async process(facebook) {
-    const { scope, fields, returnScopes, rerequest } = this.props;
+    const { scope, fields, returnScopes, rerequest, reauthorize } = this.props;
     const loginQpts = { scope };
+    let auth_type = [];
 
     if (returnScopes) {
       loginQpts.return_scopes = true;
     }
 
     if (rerequest) {
-      loginQpts.auth_type = 'rerequest';
+      auth_type.append('rerequest');
     }
+
+    if (reauthorize) {
+      auth_type.append('reauthenticate');
+    }
+
+    loginQpts.auth_type = auth_type.join(',');
 
     const response = await facebook.login(loginQpts);
     if (response.status !== 'connected') {


### PR DESCRIPTION
Facebook API support Re-Authentication (https://developers.facebook.com/docs/facebook-login/reauthentication/). By providing auth_type = "reauthenticate" I added support for this functionality.